### PR TITLE
Made drill-cli more POSIX compliant

### DIFF
--- a/source/cli/Cli.d
+++ b/source/cli/Cli.d
@@ -60,7 +60,6 @@ int main(string[] args)
     immutable(string) exe_path = dirName(buildNormalizedPath(args[0]));
     DrillAPI drill = new DrillAPI(exe_path);
 
-    import std.functional : toDelegate;
 
     bool date = false;
     bool size = false;
@@ -90,6 +89,7 @@ int main(string[] args)
     }
     
     else if (args.length == 2){
+        import std.functional : toDelegate;
         auto selectedPrint = (date ? 
                              (size ? &resultsFoundWithSizeAndDate : &resultsFoundWithDate)
                              :(size ? &resultsFoundWithSize : &resultsFoundBare));

--- a/source/cli/Cli.d
+++ b/source/cli/Cli.d
@@ -90,8 +90,9 @@ int main(string[] args)
     }
     
     else if (args.length == 2){
-        auto selectedPrint = (date ? (size ? &resultsFoundWithSizeAndDate : &resultsFoundWithDate) : 
-                                (size ? &resultsFoundWithSize : &resultsFoundBare));
+        auto selectedPrint = (date ? 
+                             (size ? &resultsFoundWithSizeAndDate : &resultsFoundWithDate)
+                             :(size ? &resultsFoundWithSize : &resultsFoundBare));
         drill.startCrawling(args[1],toDelegate(selectedPrint));
     }
 


### PR DESCRIPTION
Uses getopt. Closes #39 

Arguments:
--help / -h
--date / -d
--size / -s

Argument bundling also possible:
drill-cli -ds "foo" would print both date and size