### PR TITLE
remove unreachable code

### DIFF
--- a/CLI/CLI.d
+++ b/CLI/CLI.d
@@ -96,7 +96,6 @@ int main(string[] args)
         case 0:
             writeln("Your operating system does not pass the executable path as first argument");
             exit(-2);
-            break;
             
         // No search string
         case 1:
@@ -106,7 +105,6 @@ int main(string[] args)
             defaultGetoptPrinter("Options:", opt.options);
             import core.stdc.stdlib : exit;
             exit(-1);
-            break;
 
         // Search string provided
         case 2:


### PR DESCRIPTION
the `break` statements are unreachable, and thus cause compilers to halt when the `-w` flag is enabled.