### PR TITLE
Add Linux AppImage build and release artifact to CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -388,7 +388,6 @@ jobs:
 
   linux-appimage:
     name: Linux AppImage CD
-    if: github.event_name != 'pull_request'
     needs: [linux-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -411,6 +410,7 @@ jobs:
         run: ./scripts/build_linux_appimage.sh "${{ github.run_number }}"
 
       - name: Smoke test Linux AppImage (Qt headless)
+        if: ${{ github.event_name != 'pull_request' }}
         env:
           QT_QPA_PLATFORM: offscreen
         run: |
@@ -442,6 +442,7 @@ jobs:
           fi
 
       - name: Upload Linux AppImage artifact
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v7.0.1
         with:
           name: Drill-linux-appimage
@@ -451,7 +452,7 @@ jobs:
           compression-level: 0
 
       - name: Cancel workflow on failure
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name != 'pull_request' }}
         run: |
           curl -sS -X POST \
             -H "Authorization: Bearer ${{ github.token }}" \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -376,6 +376,78 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel"
 
+  linux-appimage:
+    name: Linux AppImage CD
+    if: github.event_name != 'pull_request'
+    needs: [linux-tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-cd.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-cd.txt
+
+      - name: Build Linux AppImage
+        run: ./scripts/build_linux_appimage.sh "${{ github.run_number }}"
+
+      - name: Smoke test Linux AppImage (Qt headless)
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          APPIMAGE_PATH="build/Drill-v${{ github.run_number }}-linux.AppImage"
+          if [ ! -x "$APPIMAGE_PATH" ]; then
+            echo "AppImage not found or not executable: $APPIMAGE_PATH"
+            exit 1
+          fi
+
+          set +e
+          python - "$APPIMAGE_PATH" <<'PY'
+          import subprocess
+          import sys
+
+          appimage = sys.argv[1]
+          env = dict(**__import__("os").environ)
+          env["APPIMAGE_EXTRACT_AND_RUN"] = "1"
+          try:
+            completed = subprocess.run([appimage], env=env, timeout=10, check=False)
+            raise SystemExit(completed.returncode)
+          except subprocess.TimeoutExpired:
+            raise SystemExit(124)
+          PY
+          status=$?
+          set -e
+          if [ "$status" -ne 124 ] && [ "$status" -ne 0 ]; then
+            echo "Linux AppImage smoke test failed with status $status"
+            exit "$status"
+          fi
+
+      - name: Upload Linux AppImage artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: Drill-linux-appimage
+          path: build/Drill-v${{ github.run_number }}-linux.AppImage
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+
+      - name: Cancel workflow on failure
+        if: ${{ failure() }}
+        run: |
+          curl -sS -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel"
+
   # rpm:
   #   name: Linux .rpm CD
   #   if: github.event_name != 'pull_request'
@@ -444,7 +516,7 @@ jobs:
   release:
     name: Create Unified Release
     if: github.event_name != 'pull_request'
-    needs: [windows, macos, linux, arch]
+    needs: [windows, macos, linux, arch, linux-appimage]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -474,6 +546,12 @@ jobs:
           name: Drill-arch-pkg
           path: dist/arch
 
+      - name: Download Linux AppImage artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: Drill-linux-appimage
+          path: dist/linux-appimage
+
       # - name: Download RPM artifact
       #   uses: actions/download-artifact@v8.0.1
       #   with:
@@ -494,6 +572,7 @@ jobs:
             # dist/macos/*.zip
             dist/macos/*.dmg
             dist/linux/*.deb
+            dist/linux-appimage/*.AppImage
             dist/arch/*.pkg.tar.*
             dist/rpm/*.rpm
         env:

--- a/scripts/build_linux_appimage.sh
+++ b/scripts/build_linux_appimage.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUN_NUMBER="${1:-${GITHUB_RUN_NUMBER:-0}}"
+VERSION="1.0.${RUN_NUMBER}"
+
+echo "Building Linux executable..."
+DRILL_VERSION="${VERSION}" python setup.py build_exe
+
+BUILD_DIR="$(find build -maxdepth 1 -type d -name 'exe.linux-*' | head -n 1)"
+if [ -z "${BUILD_DIR}" ]; then
+  echo "Linux build directory not found under build/"
+  exit 1
+fi
+
+APPDIR="build/AppDir"
+APPIMAGE_PATH="build/Drill-v${RUN_NUMBER}-linux.AppImage"
+APPIMAGETOOL="build/appimagetool-x86_64.AppImage"
+
+echo "Preparing AppDir at ${APPDIR}..."
+rm -rf "${APPDIR}"
+mkdir -p "${APPDIR}/usr/lib/drill"
+mkdir -p "${APPDIR}/usr/bin"
+mkdir -p "${APPDIR}/usr/share/applications"
+mkdir -p "${APPDIR}/usr/share/icons/hicolor/scalable/apps"
+
+cp -a "${BUILD_DIR}/." "${APPDIR}/usr/lib/drill/"
+chmod 755 "${APPDIR}/usr/lib/drill/Drill"
+
+cat > "${APPDIR}/AppRun" <<'EOF'
+#!/usr/bin/env bash
+HERE="$(dirname "$(readlink -f "${0}")")"
+exec "${HERE}/usr/lib/drill/Drill" "$@"
+EOF
+chmod 755 "${APPDIR}/AppRun"
+
+cat > "${APPDIR}/Drill.desktop" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=Drill
+Exec=AppRun
+Icon=drill
+Categories=Utility;
+Terminal=false
+EOF
+
+cp -f "${APPDIR}/Drill.desktop" "${APPDIR}/usr/share/applications/Drill.desktop"
+cp -f "src/assets/drill.svg" "${APPDIR}/drill.svg"
+cp -f "src/assets/drill.svg" "${APPDIR}/usr/share/icons/hicolor/scalable/apps/drill.svg"
+ln -sf drill.svg "${APPDIR}/.DirIcon"
+
+if [ ! -x "${APPIMAGETOOL}" ]; then
+  echo "Downloading appimagetool..."
+  curl -fsSL -o "${APPIMAGETOOL}" \
+    "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+  chmod 755 "${APPIMAGETOOL}"
+fi
+
+echo "Building AppImage at ${APPIMAGE_PATH}..."
+ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 "${APPIMAGETOOL}" "${APPDIR}" "${APPIMAGE_PATH}"
+chmod 755 "${APPIMAGE_PATH}"
+
+echo "Linux AppImage build script completed."

--- a/scripts/build_linux_appimage.sh
+++ b/scripts/build_linux_appimage.sh
@@ -23,6 +23,7 @@ mkdir -p "${APPDIR}/usr/lib/drill"
 mkdir -p "${APPDIR}/usr/bin"
 mkdir -p "${APPDIR}/usr/share/applications"
 mkdir -p "${APPDIR}/usr/share/icons/hicolor/scalable/apps"
+mkdir -p "${APPDIR}/usr/share/metainfo"
 
 cp -a "${BUILD_DIR}/." "${APPDIR}/usr/lib/drill/"
 chmod 755 "${APPDIR}/usr/lib/drill/Drill"
@@ -42,6 +43,25 @@ Exec=AppRun
 Icon=drill
 Categories=Utility;
 Terminal=false
+EOF
+
+cat > "${APPDIR}/usr/share/metainfo/Drill.appdata.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>Drill.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-only</project_license>
+  <name>Drill</name>
+  <summary>Fast file search without indexing</summary>
+  <description>
+    <p>Drill is a fast desktop file search app that works without building a background index.</p>
+  </description>
+  <launchable type="desktop-id">Drill.desktop</launchable>
+  <provides>
+    <binary>drill</binary>
+  </provides>
+  <url type="homepage">https://github.com/yatima1460/Drill</url>
+</component>
 EOF
 
 cp -f "${APPDIR}/Drill.desktop" "${APPDIR}/usr/share/applications/Drill.desktop"

--- a/scripts/build_linux_appimage.sh
+++ b/scripts/build_linux_appimage.sh
@@ -16,6 +16,7 @@ fi
 APPDIR="build/AppDir"
 APPIMAGE_PATH="build/Drill-v${RUN_NUMBER}-linux.AppImage"
 APPIMAGETOOL="build/appimagetool-x86_64.AppImage"
+DESKTOP_ID="software.drill.Drill.desktop"
 
 echo "Preparing AppDir at ${APPDIR}..."
 rm -rf "${APPDIR}"
@@ -35,7 +36,7 @@ exec "${HERE}/usr/lib/drill/Drill" "$@"
 EOF
 chmod 755 "${APPDIR}/AppRun"
 
-cat > "${APPDIR}/Drill.desktop" <<'EOF'
+cat > "${APPDIR}/${DESKTOP_ID}" <<'EOF'
 [Desktop Entry]
 Type=Application
 Name=Drill
@@ -48,7 +49,7 @@ EOF
 cat > "${APPDIR}/usr/share/metainfo/Drill.appdata.xml" <<'EOF'
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>Drill.desktop</id>
+  <id>software.drill.Drill.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0-only</project_license>
   <name>Drill</name>
@@ -56,15 +57,15 @@ cat > "${APPDIR}/usr/share/metainfo/Drill.appdata.xml" <<'EOF'
   <description>
     <p>Drill is a fast desktop file search app that works without building a background index.</p>
   </description>
-  <launchable type="desktop-id">Drill.desktop</launchable>
+  <launchable type="desktop-id">software.drill.Drill.desktop</launchable>
   <provides>
     <binary>drill</binary>
   </provides>
-  <url type="homepage">https://github.com/yatima1460/Drill</url>
+  <url type="homepage">https://drill.software</url>
 </component>
 EOF
 
-cp -f "${APPDIR}/Drill.desktop" "${APPDIR}/usr/share/applications/Drill.desktop"
+cp -f "${APPDIR}/${DESKTOP_ID}" "${APPDIR}/usr/share/applications/${DESKTOP_ID}"
 cp -f "src/assets/drill.svg" "${APPDIR}/drill.svg"
 cp -f "src/assets/drill.svg" "${APPDIR}/usr/share/icons/hicolor/scalable/apps/drill.svg"
 ln -sf drill.svg "${APPDIR}/.DirIcon"


### PR DESCRIPTION
## Summary
- add a dedicated `linux-appimage` CD job
- add `scripts/build_linux_appimage.sh` to build a cx_Freeze AppImage artifact
- smoke test the AppImage headlessly in CI
- include AppImage in the unified release artifact set

## Why
Issue #95 asks whether AppImage builds are no longer provided. This PR restores AppImage output in the CD pipeline and release bundle.

Fixes #95