### PR TITLE
Group release download buttons by OS category

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -199,6 +199,19 @@
           return years === 1 ? "1 year ago" : years + " years ago";
         };
 
+        const createOsSection = (title) => {
+          const section = document.createElement("section");
+          section.className = "download-group";
+          const heading = document.createElement("h3");
+          heading.className = "download-group-title";
+          heading.textContent = title;
+          const actions = document.createElement("div");
+          actions.className = "download-group-actions";
+          section.appendChild(heading);
+          section.appendChild(actions);
+          return { section, actions };
+        };
+
         const renderButtons = (release) => {
           actionsRoot.innerHTML = "";
           const assets = Array.isArray(release && release.assets) ? release.assets : [];
@@ -240,14 +253,26 @@
           }
 
           if (assets.length > 0) {
+            const sections = {
+              windows: createOsSection("Windows"),
+              linux: createOsSection("Linux"),
+              macos: createOsSection("macOS"),
+            };
             assets.forEach((asset) => {
               if (!asset || !asset.browser_download_url) return;
               const label = getFriendlyAssetLabel(asset.name);
               const osType = getOsType(asset.name);
+              if (!sections[osType]) return;
               const osIcon = getOsIcon(asset.name);
-              actionsRoot.appendChild(
+              sections[osType].actions.appendChild(
                 createButton(label, asset.browser_download_url, "btn btn-primary", false, osIcon, osType)
               );
+            });
+            sections.linux.actions.appendChild(createAurButton());
+            ["windows", "linux", "macos"].forEach((osKey) => {
+              if (sections[osKey].actions.children.length > 0) {
+                actionsRoot.appendChild(sections[osKey].section);
+              }
             });
           } else {
             const fallbackUrl =
@@ -257,8 +282,8 @@
             actionsRoot.appendChild(
               createButton("Download Latest Release", fallbackUrl, "btn btn-primary", false, "", "")
             );
+            actionsRoot.appendChild(createAurButton());
           }
-          actionsRoot.appendChild(createAurButton());
         };
 
         fetch("https://api.github.com/repos/" + repo + "/releases/latest")

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -87,10 +87,27 @@ body {
 }
 
 .hero-actions {
-  display: flex;
-  gap: 0.9rem;
-  flex-wrap: wrap;
+  display: grid;
+  gap: 0.75rem;
   margin: 0.9rem 0 1rem;
+}
+
+.download-group {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #fff;
+  padding: 0.65rem;
+}
+
+.download-group-title {
+  font-size: 0.95rem;
+  margin: 0 0 0.45rem;
+}
+
+.download-group-actions {
+  display: flex;
+  gap: 0.65rem;
+  flex-wrap: wrap;
 }
 
 .btn {


### PR DESCRIPTION
### Motivation
- Separate release download actions into clear OS-specific groups so Windows, Linux, and macOS downloads are not mixed together.
- Place the AUR link explicitly under the Linux group so Arch/AUR stays with other Linux options.
- Adjust hero-area layout so grouped download cards display cleanly and remain responsive.

### Description
- Add a `createOsSection` helper and update `renderButtons` in `docs/index.html` to collect assets into three containers (`Windows`, `Linux`, `macOS`) and append only matching assets into each container.
- Add the AUR button into the Linux section and keep the AUR fallback when no release assets are present in `docs/index.html`.
- Update `docs/styles.css` to change `.hero-actions` to a grid and add styles for `.download-group`, `.download-group-title`, and `.download-group-actions` to style the new grouped cards.

### Testing
- Ran `pytest -q`; test collection failed in this environment due to a missing system library (`libGL.so.1`) required by PyQt6, so automated tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37983ede883338f625c8516326987)