### PR TITLE
Prioritize current OS section in website downloads

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -269,8 +269,16 @@
               );
             });
             sections.linux.actions.appendChild(createAurButton());
-            ["windows", "linux", "macos"].forEach((osKey) => {
+            const defaultOrder = ["windows", "linux", "macos"];
+            const osOrder =
+              currentOs && defaultOrder.includes(currentOs)
+                ? [currentOs].concat(defaultOrder.filter((osKey) => osKey !== currentOs))
+                : defaultOrder;
+            osOrder.forEach((osKey) => {
               if (sections[osKey].actions.children.length > 0) {
+                if (currentOs && osKey !== currentOs) {
+                  sections[osKey].section.classList.add("download-group-secondary");
+                }
                 actionsRoot.appendChild(sections[osKey].section);
               }
             });

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -99,6 +99,19 @@ body {
   padding: 0.65rem;
 }
 
+.download-group-secondary {
+  padding: 0.55rem;
+}
+
+.download-group-secondary .download-group-title {
+  font-size: 0.9rem;
+}
+
+.download-group-secondary .btn {
+  font-size: 0.9rem;
+  padding: 0.64rem 1rem;
+}
+
 .download-group-title {
   font-size: 0.95rem;
   margin: 0 0 0.45rem;


### PR DESCRIPTION
### Motivation
- Ensure the detected current OS download group is shown first to improve discoverability and reduce clicks. 
- Visually de-emphasize other OS groups so the current-platform CTA stands out.

### Description
- Updated `docs/index.html` to compute an `osOrder` array that places the detected `currentOs` first and iterates in that order when appending download groups.
- Marked non-current groups with a `download-group-secondary` class when a `currentOs` is detected so they can be styled differently.
- Added CSS rules in `docs/styles.css` for `.download-group-secondary` to reduce padding, reduce the group title size, and slightly reduce button font-size/padding to make secondary groups smaller.
- Kept existing behavior that adds the AUR button to the Linux group and only renders groups that have assets.

### Testing
- Ran `pytest -q`, which failed during test collection due to an environment issue (`ImportError: libGL.so.1` when importing `PyQt6`), so automated tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37bb8c58483339eb7e91f270ed0f6)