### PR TITLE
Split macOS artifacts into Intel and Apple Silicon builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -149,10 +149,20 @@ jobs:
             -Headers @{Authorization = "Bearer $env:GITHUB_TOKEN"; Accept = "application/vnd.github+json"}
 
   macos:
-    name: macOS CD
+    name: macOS CD (${{ matrix.target.name }})
     needs: [linux-tests]
-    runs-on: macos-latest
-    timeout-minutes: 5
+    runs-on: ${{ matrix.target.runner }}
+    timeout-minutes: 8
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - name: Intel
+            runner: macos-13
+            suffix: intel
+          - name: Apple Silicon
+            runner: macos-latest
+            suffix: apple
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -215,7 +225,7 @@ jobs:
             echo "No Drill.app found"
             exit 1
           fi
-          APP_ZIP="build/Drill-v${{ github.run_number }}-macos-app.zip"
+          APP_ZIP="build/Drill-v${{ github.run_number }}-macos-${{ matrix.target.suffix }}-app.zip"
           ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$APP_ZIP"
           echo "Created $APP_ZIP"
 
@@ -227,16 +237,16 @@ jobs:
             echo "No DMG found"
             exit 1
           fi
-          cp "$DMG_PATH" "build/Drill-v${{ github.run_number }}-macos.dmg"
+          cp "$DMG_PATH" "build/Drill-v${{ github.run_number }}-macos-${{ matrix.target.suffix }}.dmg"
 
       - name: Upload macOS artifacts
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: Drill-macos-bundles
+          name: Drill-macos-bundles-${{ matrix.target.suffix }}
           path: |
             # build/Drill-v${{ github.run_number }}-macos-app.zip
-            build/Drill-v${{ github.run_number }}-macos.dmg
+            build/Drill-v${{ github.run_number }}-macos-${{ matrix.target.suffix }}.dmg
           if-no-files-found: error
           retention-days: 7
           compression-level: 0
@@ -550,11 +560,17 @@ jobs:
           name: Drill-windows-zip
           path: dist/windows
 
-      - name: Download macOS artifacts
+      - name: Download macOS Intel artifacts
         uses: actions/download-artifact@v8.0.1
         with:
-          name: Drill-macos-bundles
-          path: dist/macos
+          name: Drill-macos-bundles-intel
+          path: dist/macos-intel
+
+      - name: Download macOS Apple Silicon artifacts
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: Drill-macos-bundles-apple
+          path: dist/macos-apple
 
       - name: Download Linux artifact
         uses: actions/download-artifact@v8.0.1
@@ -591,8 +607,10 @@ jobs:
           generate_release_notes: true
           files: |
             dist/windows/*.zip
-            # dist/macos/*.zip
-            dist/macos/*.dmg
+            # dist/macos-intel/*.zip
+            # dist/macos-apple/*.zip
+            dist/macos-intel/*.dmg
+            dist/macos-apple/*.dmg
             dist/linux/*.deb
             dist/linux-appimage/*.AppImage
             dist/arch/*.pkg.tar.*

--- a/docs/index.html
+++ b/docs/index.html
@@ -136,8 +136,20 @@
           const name = String(assetName || "").toLowerCase();
           if (!name) return "Download";
           if (name.includes("windows")) return "Windows x64";
-          if (name.includes("macos") && name.endsWith(".dmg")) return "macOS .dmg";
-          if (name.includes("macos") && name.endsWith(".zip")) return "macOS .app.zip";
+          if (name.includes("macos") && name.includes("-apple") && name.endsWith(".dmg")) {
+            return "macOS Apple Silicon (.dmg)";
+          }
+          if (name.includes("macos") && name.includes("-intel") && name.endsWith(".dmg")) {
+            return "macOS Intel (.dmg)";
+          }
+          if (name.includes("macos") && name.includes("-apple") && name.endsWith(".zip")) {
+            return "macOS Apple Silicon (.app.zip)";
+          }
+          if (name.includes("macos") && name.includes("-intel") && name.endsWith(".zip")) {
+            return "macOS Intel (.app.zip)";
+          }
+          if (name.includes("macos") && name.endsWith(".dmg")) return "macOS (.dmg)";
+          if (name.includes("macos") && name.endsWith(".zip")) return "macOS (.app.zip)";
           if (name.includes("linux") && name.endsWith(".deb")) return "Linux .deb";
           if (name.includes("linux") && name.endsWith(".rpm")) return "Linux .rpm";
           if (name.endsWith(".appimage")) return "Linux AppImage x64";


### PR DESCRIPTION
### Motivation
- Avoid producing a universal macOS app and instead provide separate Intel and Apple Silicon builds so releases can offer architecture-specific downloads.  
- Keep the build matrix in a single macOS CD job rather than adding separate CD workflows.  
- Reflect the per-architecture artifacts on the website so users can clearly choose the correct macOS download.

### Description
- Converted the `macos` CD job to a matrix with `Intel` (`macos-13`) and `Apple Silicon` (`macos-latest`) targets and used `matrix.target.runner` for `runs-on`.  
- Updated artifact names and upload steps to append `-intel` / `-apple` suffixes (e.g. `Drill-v${{ github.run_number }}-macos-intel.dmg`) and to upload per-architecture artifact bundles.  
- Adjusted the release aggregation step to download both `Drill-macos-bundles-intel` and `Drill-macos-bundles-apple` and to publish both DMGs in the GitHub release.  
- Updated `docs/index.html` asset labeling logic so macOS buttons show `macOS Intel` and `macOS Apple Silicon` variants for both `.dmg` and `.app.zip` filenames.

### Testing
- Verified the modified workflow YAML parses with Ruby via `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cd.yml")'`, which succeeded.  
- Attempted a PyYAML parse with Python, but the environment lacks `pyyaml` so that check could not be run.  
- Ran `node --check docs/index.html` which is not applicable to raw HTML and therefore failed as expected for this check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37d40007c83339cf497583c043aa7)